### PR TITLE
fix: losing information for screen orientation

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -18,7 +18,8 @@
             android:name=".MainActivity"
             android:exported="true"
             android:label="@string/app_name"
-            android:theme="@style/Theme.TestTimeTonic">
+            android:theme="@style/Theme.TestTimeTonic"
+            android:screenOrientation="portrait">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 


### PR DESCRIPTION
I forgot to test the screen orientation, the best approach for this error
could be using shared preferences, but this is a quick fix, I'll keep it in mind
for future references